### PR TITLE
Glimpse simplify widget setup

### DIFF
--- a/glimpse/README.md
+++ b/glimpse/README.md
@@ -30,28 +30,30 @@ _Read the main [README](../#micro-scripts) to learn how this should be `$include
 
 # Configurations
 ## Setting up
-This requires Glance’s search layout. Set up your search widget first (if you haven’t already) by following their configuration doc: https://github.com/glanceapp/glance/blob/v0.8.3/docs/configuration.md#search-widget
+Check the [Glance Search Properties](https://github.com/glanceapp/glance/blob/v0.8.4/docs/configuration.md#properties-10), it should be almost similar in terms of configuration. Here's a quick configuration to get you started:
+```javascript
+  const glanceSearch = { 
+    searchUrl: 'https://duckduckgo.com/?q={QUERY}',
+    newTab: true,
+    autofocus: false,
+    target: '_blank',
+    placeholder: 'Type here to search…',
+    bangs: [
+      { title: 'Google', shortcut: '!g', url: 'https://www.google.com/search?q={QUERY}' },
+      { title: 'Bing', shortcut: '!b', url: 'https://www.bing.com/search?q={QUERY}' },
+    ]
+  };
+```
 
-### Copying the search widget
-Once it’s set up and visible, you’ll need to copy its HTML structure.
-
-*Instructions may vary depending on your browser*
-1. Open DevTools (F12, [more info](https://developer.chrome.com/docs/devtools/open))
-2. In the Elements or Inspector tab, select Glance’s Search element (Ctrl+Shift+C)
-3. Ensure the element has a class containing `widget-type-search`, right-click it, then choose `Copy` > `Copy Outer HTML`
-4. In `pre-glance.js`, paste the copied HTML into the `glanceSearch` variable
-
-### Search Suggestion
+## Search Suggestion
 Due to [some limitations](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/CORS) and the fact this is a client script, you’ll need to proxy external search suggestions (e.g., from DuckDuckGo or Google) using a service like your own Node.js server.
 
-For `searchEngineEndpoint`, copy the value from the data `data-default-search-url` attribute of the search widget you copied, and assign it to this variable.
-
-For `searchSuggestEndpoint`, use the URL of your proxy endpoint. If you're using something like [Whoogle-Search](https://github.com/benbusby/whoogle-search), the endpoint would be `/autocomplete?q=`, so you would set it like this: `https://whoogle.mydomain.com/autocomplete?q=`.
+For `searchSuggestEndpoint`, use the URL of your proxy endpoint. If you're using something like [Whoogle-Search](https://github.com/benbusby/whoogle-search), the endpoint would be `/autocomplete?q=`, so you would set it like this: `https://your-whoogle-domain.com/autocomplete?q=`.
 
 ## Other page search
 By default, Glimpse searches only the currently loaded page. To include other pages, set the `pagesSlug` array variable with your primary page's slug and any additional pages.
 
-Slugs are used instead of titles or page names since they can be [custom-defined](https://github.com/glanceapp/glance/blob/v0.8.3/docs/configuration.md#slug).
+Slugs are used instead of titles or page names since they can be [custom-defined](https://github.com/glanceapp/glance/blob/v0.8.4/docs/configuration.md#slug).
 
 > [!NOTE]
 >

--- a/glimpse/README.md
+++ b/glimpse/README.md
@@ -40,7 +40,6 @@ Once it’s set up and visible, you’ll need to copy its HTML structure.
 2. In the Elements or Inspector tab, select Glance’s Search element (Ctrl+Shift+C)
 3. Ensure the element has a class containing `widget-type-search`, right-click it, then choose `Copy` > `Copy Outer HTML`
 4. In `pre-glance.js`, paste the copied HTML into the `glanceSearch` variable
-5. Disable Glance’s built-in search to avoid conflicts with the keybinding used by this script
 
 ### Search Suggestion
 Due to [some limitations](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/CORS) and the fact this is a client script, you’ll need to proxy external search suggestions (e.g., from DuckDuckGo or Google) using a service like your own Node.js server.
@@ -97,5 +96,5 @@ css-class: glimpsable-hidden
 | Variables           | Default | Description |
 |---------------------|---------|---------------------------|
 | `cleanupOtherPages` | true | Whether to clean the iframes or not. Can lead to high usage if set to `false` but could otherwise speed up your widget queries |
-| `glimpseKey` | s | The shortcut key to call Glimpse, used the 's' by default from Glance |
-| `waitForGlance` | true | Setting this to `false` will make the search and search-bangs functionality of Glance not work as those are loaded after Glance is ready, Glimpse functionality will remain working. This just limits when the `glimpseKey` can be triggered. |
+| `glimpseKey` | '' | The shortcut key to call Glimpse, set to empty `''` by default to disable. *Setting this to `'s'` will override Glance's default search key focus* |
+| `waitForGlance` | true | Setting this to `false` will make the search and search-bangs functionality of Glance not work as those are loaded after Glance is ready, Glimpse functionality will remain working. This just limits when the `glimpseKey` can be triggered |

--- a/glimpse/pre-glance.js
+++ b/glimpse/pre-glance.js
@@ -5,14 +5,14 @@
   `;
   const searchEngineEndpoint = ``;
   const searchSuggestEndpoint = ``;
-  // Other page search may or may not work due to limitations, and is slow
+  // Other page search may or may not work due to limitations, and can be slow
   const pagesSlug = [
     // 'home-page',
     // 'page-1',
     // 'page-2',
   ];
   const cleanupOtherPages = true; // Warning: setting this to false is like having (# of pagesSlug) tabs opened all at once
-  const glimpseKey = 's'; // Can not override the Glance's default key 's' to focus.
+  const glimpseKey = '';
   const waitForGlance = true;
 
   const loadingAnimationElement = document.createElement('div');
@@ -112,10 +112,18 @@
   searchInput.addEventListener('input', handleInput);
 
   document.addEventListener('keydown', event => {
-    if (event.key === glimpseKey && document.activeElement !== searchInput) {
+    const activeElement = document.activeElement;
+
+    // If Glance's search input is focused then prevent spawn
+    if (activeElement.classList.contains('search-input') && activeElement.closest('.widget-type-search') && !activeElement.closest('#glimpse')) {
+      return;
+    }
+
+    if (glimpseKey && event.key === glimpseKey && activeElement !== searchInput) {
       event.preventDefault();
       if ((waitForGlance && document.body.classList.contains('page-columns-transitioned')) || !waitForGlance) spawnGlimpse();
     }
+
     if (event.key === 'Escape') closeGlimpse();
   });
 


### PR DESCRIPTION
This replaces the way the search widget is configured by using a JavaScript object instead of copying the HTML element and everything.

# Fix
- https://github.com/glanceapp/glance/commit/d103c81df19421b170961bfc390e66d23c5da073