### PR TITLE
(responsive-table): rewritten the logic

### DIFF
--- a/responsive-table/README.md
+++ b/responsive-table/README.md
@@ -15,7 +15,7 @@ This is a client-only implementation—**no server-side support**—because of h
 
 > [!WARNING]
 >
-> Large datasets are **strongly discouraged**. All data is initially rendered into the DOM before this Script removes and stores it in memory.
+> Large datasets are **strongly discouraged**. All data is stored and queried directly from the DOM, which may impact performance.
 >
 > Pagination limits what's shown, but the full dataset remains in your browser. This can lead to major slowdowns or even browser crashes.
 >
@@ -24,40 +24,46 @@ This is a client-only implementation—**no server-side support**—because of h
 # Usage
 ## Structure Layout
 ```html
-<div responsive-table>          <!-- Main table container -->
-    <div table-header>          <!-- Table header container -->
-        <div>Header 1</div>     <!-- Each column header -->
+<template responsive-table>           <!-- Main table container -->
+  <div table-pagination-options />    <!-- Required, pagination options -->
+  <div table-header>                  <!-- Table header container -->
+    <div>Header 1</div>               <!-- Each column header -->
+  </div>
+  <div table-body>                    <!-- Row items container -->
+    <div table-row>                   <!-- Container of each cell of the row -->
+      <div>Item 1</div>               <!-- The Cell item, must match header count -->
     </div>
-    <div table-body>            <!-- Row items container -->
-        <div table-row>         <!-- Container of each cell of the row -->
-            <div>Item 1</div>   <!-- The Cell item, must match header count -->
-        </div>
-    </div>
-</div>
+  </div>
+</template>
 ```
 
 ## Structure Info
 `responsive-table`
 
-A lightweight component for rendering responsive, paginated data tables using custom headers and rows.
-
-**Attributes**
-- `paginate`: Enables paginated layout for the table.
-- `row-limit`: Defines the maximum number of visible rows per page. Requires `paginate` to be enabled.
-- `row-limit-mobile`: Overrides `row-limit` on mobile devices. Requires `paginate` to be enabled.
+Will be the fragment container for your data-table.
 
 **Child Elements**
+- `table-pagination-options`
+  
+    **Attributes**
+    - `min-height`: minimum height of the table as `number`, this should prevent layout shifting. Can be unset but defaults to 120. Gets converted to a `px`
+    - `min-height-mobile`: similar to `min-height` but for mobile.
+    - `page-size`: visible rows per page.
+    - `page-size-mobile`: same with `page-size` but for mobile view.
+    - `total-entries`: Array Length of the Table, this should be set in the custom-api template
+  
+
 - `table-header`
 
     **Attributes (per column)**
     - `sortable`: Enables sorting on the column.
     - `data-width`: Defines the column's proportional width (e.g., `3` for `3fr`).
-    - `sort-default-asc` / `sort-default-desc`: Sets the default sort order to ascending or descending, respectively. These are mutually exclusive—only one of them should be used. If both are present, only the first column with either attribute takes effect.
+    - `data-sort-direction`: Sets the default sort order to `asc`ending or `desc`ending. These are mutually exclusive—only one of them should be used. If both are present, only the first column with the attribute takes effect.
 
 - `table-body`: Contains the list of data rows.
 
     **Child Elements**
-    - `table-row`: Represents a single data row.
+    - `table-row`: Represents a single data row, must have and index value from the loop of data
 
         **Attributes (per cell)**
         - `data-show-on-mobile`: By default, every cell is collapsed on mobile. Set this to make them visible instead.
@@ -67,36 +73,41 @@ A lightweight component for rendering responsive, paginated data tables using cu
 
 All rows must maintain the same number of cells as defined in the header.
 
-## Alternative style
-Glance includes a built-in collapsible-container you can use directly inside `table-body`. It automatically handles content collapsing and expands on demand.
-```html
-<div table-body class="list collapsible-container" data-collapse-after="5"></div>
-```
-Set `data-collapse-after` to control how many items show before collapsing.
-
 
 ## Example
 ```html
-<div responsive-table paginate row-limit="5" row-limit-mobile="3">
-    <div table-header>
-        <div sortable>ID</div>
-        <div sortable data-width="3">Name</div>
-        <div sortable>Price</div>
-        <div sortable sort-default-asc>Availability</div>
+<div responsive-table>
+  <div table-pagination-options
+    min-height="497"
+    min-height-mobile="605.5"
+    page-size="10"
+    page-size-mobile="5"
+    total-entries="30"
+  ></div>
+  <div table-header>
+    <div sortable>ID</div>
+    <div sortable data-width="3">Name</div>
+    <div sortable>Price</div>
+    <div sortable data-sort-direction="asc">Availability</div>
+  </div>
+  <div table-body>
+    <div table-row="1">
+      <div>1</div>
+      <div data-as-mobile-title>item_1</div>
+      <div data-as-collapsed-column>$10.00</div>
+      <div data-show-on-mobile class="color-positive">Available</div>
     </div>
-    <div table-body>
-        <div table-row>
-            <div>1</div>
-            <div data-as-mobile-title>item_1</div>
-            <div data-as-collapsed-column>$10.00</div>
-            <div data-show-on-mobile class="color-positive">Available</div>
-        </div>
-        <div table-row>
-            <div>2</div>
-            <div data-as-mobile-title>item_2</div>
-            <div data-as-collapsed-column>$15.00</div>
-            <div data-show-on-mobile class="color-negative">Out of stock</div>
-        </div>
+    <div table-row="2">
+      <div>2</div>
+      <div data-as-mobile-title>item_2</div>
+      <div data-as-collapsed-column>$15.00</div>
+      <div data-show-on-mobile class="color-negative">Out of stock</div>
     </div>
+  </div>
 </div>
 ```
+
+### Example Widgets
+- [Beszel System Table](https://github.com/ralphocdol/glance-custom-widgets/tree/main/custom-api/beszel-system-table)
+- [OMV Drives Table](https://github.com/ralphocdol/glance-custom-widgets/tree/main/custom-api/omv-drives-table)
+- [ProxmoxVE VM/LXC Table](https://github.com/ralphocdol/glance-custom-widgets/tree/main/custom-api/proxmox-ve-table)

--- a/responsive-table/README.md
+++ b/responsive-table/README.md
@@ -52,7 +52,7 @@ Will be the fragment container for your data-table.
     - `min-height`: minimum height of the table as `number`, this should prevent layout shifting. Can be unset but defaults to 120. Gets converted to a `px`
     - `min-height-mobile`: similar to `min-height` but for mobile.
     - `page-size`: visible rows per page.
-    - `page-size-mobile`: same with `page-size` but for mobile view.
+    - `page-size-mobile`: similar to `page-size` but for mobile view.
     - `total-entries`: Array Length of the Table, this should be set in the custom-api template
   
 

--- a/responsive-table/README.md
+++ b/responsive-table/README.md
@@ -3,6 +3,9 @@
 ![preview1](preview/preview1.webp)
 ![preview2](preview/preview2.webp)
 
+# Dependency
+- [CREATE_ELEMENT](../global-functions/CREATE_ELEMENT.js) *(required)*
+
 # How to load
 Read the main [README.md](https://github.com/ralphocdol/glance-addon-scripts/blob/main/README.md#loading-script) on how to properly load this.
 ```html

--- a/responsive-table/script.js
+++ b/responsive-table/script.js
@@ -327,7 +327,6 @@ document.addEventListener('DOMContentLoaded', async () => {
           {
             tag: 'ul',
             classes: 'list list-with-transition size-h5',
-            style: { '--table-template': templateStyle },
             children: Array.from(cells)
               .filter(c => !c.hasAttribute('data-show-on-mobile') && !c.hasAttribute('data-as-mobile-title'))
               .map((c, i) => {

--- a/responsive-table/script.js
+++ b/responsive-table/script.js
@@ -83,11 +83,13 @@ document.addEventListener('DOMContentLoaded', async () => {
       style: inheritStyles(bodyElement),
     });
 
-    const commonParameters = { headerElement, bodyElement, tableBody, templateStyle, targetPages };
 
     headerElement.addEventListener('click', e => {
       const h = e.target.closest('[sortable]');
       if (!h) return;
+      const newPageSize = !maxWidthMedia.matches ? pageSize : pageSizeMobile;
+      const targetPages = { start: 0, end: newPageSize - 1 };
+      const commonParameters = { headerElement, bodyElement, tableBody, templateStyle, targetPages };
       const direction = h.dataset.sortDirection === 'asc' ? 'desc' : 'asc';
       headerElementColumns.forEach(c => delete c.dataset.sortDirection);
 
@@ -127,7 +129,6 @@ document.addEventListener('DOMContentLoaded', async () => {
               if (!isNaN(page)) {
                 const start = (+page - 1) * newPageSize;
                 const targetPages = { start, end: start + newPageSize - 1 };
-                paginationOptions.setAttribute('current-page', +page);
                 updatePagination({ footer, paginationOptions, currentPage: +page, targetPages });
                 updateRowPage({ headerElement, bodyElement, tableBody, templateStyle, targetPages });
               } else {
@@ -160,7 +161,14 @@ document.addEventListener('DOMContentLoaded', async () => {
 
     function displayChange(e) {
       let targetPages = { start: 0, end: pageSize - 1 };
-      if (e.matches) targetPages = { start: 0, end: pageSizeMobile - 1 };
+      let newMinHeight = minHeight;
+
+      if (e.matches) {
+        targetPages = { start: 0, end: pageSizeMobile - 1 };
+        newMinHeight = minHeightMobile;
+      }
+      tableEl.style.minHeight = newMinHeight + 'px';
+
       const commonParameters = { headerElement, bodyElement, tableBody, templateStyle, targetPages };
       updatePagination({ footer, paginationOptions, currentPage, targetPages });
       sortTableDataset(commonParameters, sortedHeaderIndex, sortedHeader?.dataset.sortDirection || 'asc');
@@ -221,6 +229,9 @@ document.addEventListener('DOMContentLoaded', async () => {
                   const sortedHeader = headerElementColumns.find(isSorted);
                   const sortedHeaderIndex = headerElementColumns.findIndex(isSorted);
                   if (sortedHeader) {
+                    const newPageSize = !maxWidthMedia.matches ? pageSize : pageSizeMobile;
+                    const targetPages = { start: 0, end: newPageSize - 1 };
+                    const commonParameters = { headerElement, bodyElement, tableBody, templateStyle, targetPages };
                     const direction = sortedHeader?.dataset.sortDirection === 'asc' ? 'desc' : 'asc';
                     headerElementColumns.forEach(c => delete c.dataset.sortDirection);
 
@@ -232,7 +243,7 @@ document.addEventListener('DOMContentLoaded', async () => {
                       direction
                     );
                   }
-                  setTimeout(() => thisEl.disabled = false, 100);
+                  setTimeout(() => thisEl.disabled = false, 100); // prevent spam click glitch
                 }
               }
             }

--- a/responsive-table/script.js
+++ b/responsive-table/script.js
@@ -1,4 +1,6 @@
 'use strict';
+const CURRENT_SCRIPT_TIMESTAMP = new URL(import.meta.url).searchParams.get('v') || '';
+
 document.addEventListener('DOMContentLoaded', async () => {
   // Catch duplicate instances
   const scriptName = 'Responsive Table';
@@ -11,430 +13,477 @@ document.addEventListener('DOMContentLoaded', async () => {
     window.GLANCE_ADDON_SCRIPTS[scriptName] = true;
   }
 
+  // Catch Missing Dependencies
+  const { default: createElementFn } = await import(`../global-functions/CREATE_ELEMENT.js?v=${CURRENT_SCRIPT_TIMESTAMP}`);
+  if (typeof createElementFn !== 'function') {
+    const msg = 'The global-function CREATE_ELEMENT not found, read the dependency in the README.md of this script.';
+
+    if (typeof window.showToast === 'function') window.showToast?.(msg, { title: 'CUSTOM SETTINGS', type: 'error' });
+    else alert(msg);
+
+    console.error('CREATE_ELEMENT not found');
+    return;
+  }
+
   while (!document.body.classList.contains('page-columns-transitioned')) await new Promise(resolve => setTimeout(resolve, 50));
 
-  // Sort stuff
-  const colSorted = [];
-  const colSortedDirection = [];
+  let restoreAttachedElements = [];
 
-  // Pagination stuff
-  const data = [];
-  const dataTable = [];
-  const dataPage = [];
-  const dataPageLimit = [];
-  const isPaginate = [];
+  document.querySelectorAll('template[responsive-table]').forEach((t, t_index) => {
+    const templateContent = t.content;
+    if (!templateContent) return console.error('Missing Required: template content');
 
-  let paginationBtnControllers = [];
+    const headerElement = templateContent.querySelector('[table-header]');
+    if (!headerElement) return console.error('Missing Required: table-header');
 
-  document.querySelectorAll('[responsive-table]').forEach((t, t_index) => {
-    const header = t.querySelector('[table-header]');
-    if (!header) return console.error('Missing Required: table-header');
-    const body = t.querySelector('[table-body]');
-    if (!body) return console.error('Missing Required: table-body');
-    const rows = body.querySelectorAll('[table-row]');
-    if (!rows) return console.error('Missing Required: table-rows');
+    const bodyElement = templateContent.querySelector('[table-body]');
+    if (!bodyElement) return console.error('Missing Required: table-body');
 
-    data[t_index] = Array.from(rows, r => r.cloneNode(true));
-    const rowsData = data[t_index];
-    body.innerHTML = '';
+    const paginationOptions = templateContent.querySelector('[table-pagination-options]');
+    if (!paginationOptions) return console.error('Missing Required: table-pagination-options');
 
-    const headerCells = [...header.children];
+    const minHeight = +paginationOptions.getAttribute('min-height') || 120;
+    const pageSize = +paginationOptions.getAttribute('page-size');
+    const totalEntries = +paginationOptions.getAttribute('total-entries');
+    const totalPage = Math.ceil(totalEntries / pageSize);
+    paginationOptions.setAttribute('total-page', totalPage);
+    paginationOptions.setAttribute('current-page', 1);
 
-    const totalColumns = headerCells.length;
-    t.style.setProperty('--table-columns', totalColumns);
+    const targetPages = { start: 0, end: pageSize - 1 };
 
-    const template = headerCells.map(h => (h.dataset.width || '1') + 'fr');
-    header.style.setProperty('--table-template', template.join(' '));
+    const tableEl = createElementFn({
+      attrs: { role: 'table', 'responsive-table': '' },
+      style: { minHeight: minHeight + 'px' },
+    });
 
-    colSorted[t_index] = 0;
-    colSortedDirection[t_index] = 'asc';
+    const templateStyle = headerElement.children.map(h => (h.dataset.width || '1') + 'fr').join(' ');
+    headerElement.style.setProperty('--table-template', templateStyle);
+    headerElement.setAttribute('role', 'rowgroup');
+    const headerElementColumns = Array.from(headerElement.children);
+    headerElementColumns.forEach(c => c.setAttribute('role', 'columnheader'));
 
-    const enablePaginate = true;
-    isPaginate[t_index] = enablePaginate && t.hasAttribute('paginate');
-    if (isPaginate[t_index]) {
-      body.classList.remove('list', 'collapsible-container');
-      delete body.dataset.collapseAfter;
-      t.querySelector('button.expand-toggle-button')?.remove();
+    const tableBody = createElementFn({
+      attrs: { role: 'rowgroup', 'table-body': '' },
+    });
 
-      data[t_index] = Array.from(rowsData, r => {
-        r.classList.remove('collapsible-item');
-        r.style.removeProperty('animation-delay');
-        return r;
-      });
+    const commonParameters = { headerElement, bodyElement, tableBody, templateStyle, targetPages };
 
-      dataPageLimit[t_index] = t.getAttribute(window.matchMedia('(max-width: 768px)').matches ? 'row-limit-mobile' : 'row-limit') || t.getAttribute('row-limit') || 10;
-
-      body.innerHTML = '';
-      dataTable[t_index] = data[t_index].slice(0, dataPageLimit[t_index]);
-      dataPage[t_index] = 1;
-
-      createPagination({ t, t_index, header, headerCells, body, template })
-    }
-    setupTable({ t, t_index, header, headerCells, body, template });
-    setupMobileSort({ headerCells, t, t_index, body });
-
-    header.addEventListener('click', e => {
+    headerElement.addEventListener('click', e => {
       const h = e.target.closest('[sortable]');
       if (!h) return;
+      const direction = h.dataset.sortDirection === 'asc' ? 'desc' : 'asc';
+      headerElementColumns.forEach(c => delete c.dataset.sortDirection);
 
-      colSorted[t_index] = [...h.parentElement.children].indexOf(h);
-      colSortedDirection[t_index] = h.dataset.sortDirection === 'asc' ? 'desc' : 'asc';
-      h.dataset.sortDirection = colSortedDirection[t_index];
-
-      sortTable({ t, t_index, body });
+      tableEl.querySelector('.table-sort-direction').dataset.sortDirection = direction;
+      h.dataset.sortDirection = direction;
+      sortTableDataset(
+        commonParameters,
+        [...h.parentElement.children].indexOf(h),
+        direction
+      );
     });
 
-    t.style.display = 'block';
-    t.classList.add('show');
+    tableEl.appendChild(headerElement);
 
-    body.style.minHeight = body.offsetHeight + 'px';
+    const isSorted = c => c.hasAttribute('sortable') && c.hasAttribute('data-sort-direction');
+    const sortedHeader = headerElementColumns.find(isSorted);
+    const sortedHeaderIndex = headerElementColumns.findIndex(isSorted);
+
+    // Initial Page Load
+    sortTableDataset(commonParameters, sortedHeaderIndex, sortedHeader?.dataset.sortDirection || 'asc');
+
+    tableEl.appendChild(tableBody);
+
+    const currentPage = +paginationOptions.getAttribute('current-page');
+
+    const footer = createElementFn({
+      classes: 'pagination-container',
+      children: [
+        {
+          classes: 'pagination-summary',
+          htmlContent: `Showing <span summary-current>${currentPage}</span> to <span summary-size>${pageSize}</span> of ${totalEntries} entries`
+        },
+        {
+          classes: 'pagination-buttons',
+          events: {
+            click: e => {
+              if (!e.target.classList.contains('page-btn')) return;
+              const btn = e.target.textContent;
+              if (!isNaN(btn)) {
+                const start = (+btn - 1) * pageSize;
+                const targetPages = { start, end: start + pageSize - 1 };
+                paginationOptions.setAttribute('current-page', +btn);
+                updatePagination({ footer, totalPage, paginationOptions, currentPage: +btn, targetPages });
+                updateRowPage({ headerElement, bodyElement, tableBody, templateStyle, targetPages });
+              } else {
+                const currentPage = +paginationOptions.getAttribute('current-page');
+                let start = 1;
+                let newCurrentPage;
+
+                if (btn === '←' && currentPage > 1) {
+                  start = (currentPage - 2) * pageSize;
+                  newCurrentPage = currentPage - 1;
+                } else if (btn === '→' && currentPage < totalPage) {
+                  start = currentPage * pageSize;
+                  newCurrentPage = currentPage + 1;
+                } else {
+                  return;
+                }
+
+                const targetPages = { start, end: start + pageSize - 1 };
+                updatePagination({ footer, totalPage, paginationOptions, currentPage: newCurrentPage, targetPages });
+                updateRowPage({ headerElement, bodyElement, tableBody, templateStyle, targetPages });
+              }
+            }
+          }
+        }
+      ]
+    });
+
+    updatePagination({ footer, totalPage, paginationOptions, currentPage, targetPages });
+    tableEl.appendChild(footer);
+
+    const mobileSortContainer = createElementFn({
+      classes: 'table-sort',
+      children: [
+        {
+          tag: 'label',
+          textContent: 'Sort by:',
+          props: { htmlFor: 'responsive-table-mobile-sort-select-' + t_index },
+          children: [
+            {
+              tag: 'select',
+              classes: 'table-sort-option',
+              id: 'responsive-table-mobile-sort-select-' + t_index,
+              htmlContent: `
+                <option disabled selected>Sort by...</option>
+                ${[...headerElement.children]
+                  .filter(c => !c.hasAttribute('data-as-collapsed-header') && c.hasAttribute('sortable'))
+                  .map((c, i) => {
+                    return `<option value="${i}"
+                      ${sortedHeaderIndex === i ? 'selected' : ''}>${c.innerText.trim()}
+                    </option>`
+                  })
+                  .join('')
+                }
+              `,
+              events: {
+                change: (e, thisEl) => {
+                  const selectedHeaderIndex = e.target.value;
+                  const selectedHeader = headerElementColumns[selectedHeaderIndex];
+                  const direction = selectedHeader.dataset.sortDirection === 'asc' ? 'desc' : 'asc';
+                  headerElementColumns.forEach(c => delete c.dataset.sortDirection);
+
+                  thisEl.parentElement.querySelector('.table-sort-direction').disabled = isNaN(selectedHeaderIndex);
+                  selectedHeader.dataset.sortDirection = direction;
+                  sortTableDataset(
+                    { headerElement, bodyElement, tableBody, templateStyle, targetPages },
+                    selectedHeaderIndex,
+                    direction
+                  );
+                }
+              }
+            },
+            {
+              tag: 'button',
+              classes: 'table-sort-direction',
+              id: 'table-sort-direction-' + t_index,
+              datasets: { sortDirection: sortedHeader?.dataset.sortDirection || 'asc' },
+              props: { disabled: !sortedHeader },
+              events: {
+                click: (e, thisEl) => {
+                  thisEl.disabled = true;
+                  const sortedHeader = headerElementColumns.find(isSorted);
+                  const sortedHeaderIndex = headerElementColumns.findIndex(isSorted);
+                  if (sortedHeader) {
+                    const direction = sortedHeader?.dataset.sortDirection === 'asc' ? 'desc' : 'asc';
+                    headerElementColumns.forEach(c => delete c.dataset.sortDirection);
+
+                    thisEl.dataset.sortDirection = direction;
+                    sortedHeader.dataset.sortDirection = direction;
+                    sortTableDataset(
+                      commonParameters,
+                      sortedHeaderIndex,
+                      direction
+                    );
+                  }
+                  setTimeout(() => thisEl.disabled = false, 100);
+                }
+              }
+            }
+          ]
+        },
+      ]
+    });
+    tableEl.prepend(mobileSortContainer);
+
+    t.insertAdjacentElement('afterend', tableEl);
   });
 
-  function setupTable({ t, t_index, header, headerCells, body, template }) {
-    updateRows({ t_index, header, headerCells, template });
+  function sortTableDataset(params, columnIndex, direction = 'asc') {
+    const { bodyElement, tableBody } = params;
 
-    const sortable = header.querySelectorAll('[sortable]');
-    const sorted = [...sortable].some(h => h.hasAttribute('data-sort-direction'));
-    if (sorted) return sortTable({ t, t_index, body });
+    restoreAllAttachedElements(tableBody);
+    const rows = Array.from(bodyElement.children);
 
-    for (const h of sortable) {
-      const defaultDirection = h.hasAttribute('sort-default-asc') ? 'asc' :
-        h.hasAttribute('sort-default-desc') ? 'desc' : 'none';
-      h.dataset.sortDirection = defaultDirection;
+    rows
+      .sort((a, b) => {
+        const x = a.children[columnIndex]?.dataset.toSort || a.children[columnIndex]?.innerText.trim() || '';
+        const y = b.children[columnIndex]?.dataset.toSort || b.children[columnIndex]?.innerText.trim() || '';
+        const nx = isNaN(x) ? x.toLowerCase() : +x;
+        const ny = isNaN(y) ? y.toLowerCase() : +y;
+        return nx > ny ? (direction === 'asc' ? 1 : -1) : nx < ny ? (direction === 'asc' ? -1 : 1) : 0;
+      })
+      .map((el, i) => el.setAttribute('table-row', i));
 
-      if (defaultDirection !== 'none') {
-        colSorted[t_index] = [...h.parentElement.children].indexOf(h);
-        colSortedDirection[t_index] = defaultDirection;
-        sortTable({ t, t_index, body });
-        break;
+    bodyElement.append(...rows);
+    updateRowPage(params);
+  }
+
+  function updateRowPage(params) {
+    const { headerElement, bodyElement, tableBody, templateStyle, targetPages } = params;
+    const { start, end } = targetPages;
+
+    restoreAllAttachedElements(tableBody);
+
+    // Select the rows for the current page
+    const sliceRows = Array.from(bodyElement.children).filter(row => {
+      const tableRow = row.getAttribute('table-row');
+      return tableRow >= start && tableRow <= end;
+    });
+
+    if (!sliceRows.length) return;
+
+    // Apply styles and roles once per row
+    sliceRows.forEach(row => {
+      const currentTemplate = row.style.getPropertyValue('--table-template').trim();
+      if (!currentTemplate || currentTemplate === 'repeat(10, 1fr)')
+        row.style.setProperty('--table-template', templateStyle);
+
+      mobileCollapseRows({ row, headerElement, templateStyle });
+
+      if (row.getAttribute('role') !== 'row') row.setAttribute('role', 'row');
+      for (const cell of row.children) {
+        if (cell.getAttribute('role') !== 'cell') cell.setAttribute('role', 'cell');
       }
+    });
+
+    // Create a single placeholder before the first row
+    const placeholder = document.createComment('page-slice');
+    sliceRows[0].before(placeholder);
+
+    // Move all rows at once using a DocumentFragment
+    const fragment = document.createDocumentFragment();
+    sliceRows.forEach(row => fragment.appendChild(row));
+    tableBody.replaceChildren(fragment);
+
+    // Store a single restore function for the entire slice
+    restoreAttachedElements.push({
+      tableBody,
+      restore() {
+        placeholder.replaceWith(...sliceRows);
+        placeholder.remove();
+      }
+    });
+  }
+
+  function restoreAllAttachedElements(tableBody) {
+    restoreAttachedElements = restoreAttachedElements.filter(entry => {
+      if (entry.tableBody === tableBody) {
+        entry.restore();
+        return false;
+      }
+      return true;
+    });
+  }
+
+  function mobileCollapseRows(params) {
+    const { row, headerElement, templateStyle } = params;
+    const cells = row.children;
+    const headerList = Array.from(headerElement.children).map(h => h.innerText.trim());
+    const template = templateStyle.split(' ');
+
+    // only one 'data-as-mobile-title'
+    const withTitle = [...cells].filter(c => c.hasAttribute('data-as-mobile-title'));
+    if (withTitle.length > 1) {
+      withTitle.slice(1).forEach(c => c.removeAttribute('data-as-mobile-title'));
+    } else if (withTitle.length === 0 && cells.length > 0) {
+      cells[0].dataset.asMobileTitle = '';
     }
-  }
 
-  function updateRows({ t_index, header, headerCells, template }) {
-    const headerList = headerCells.map(h => h.innerText.trim());
-    data[t_index].forEach(r => {
-      const children = r.children;
+    // mobile detail summary
+    if (!row.querySelector('.responsive-table-details')) {
+      const details = createElementFn({
+        tag: 'details',
+        classes: 'details margin-top-5 responsive-table-details',
+        children: [
+          {
+            tag: 'ul',
+            classes: 'list list-with-transition size-h5',
+            style: { '--table-template': templateStyle },
+            children: Array.from(cells)
+              .filter(c => !c.hasAttribute('data-show-on-mobile') && !c.hasAttribute('data-as-mobile-title'))
+              .map((c, i) => {
+                return {
+                  tag: 'li',
+                  classes: 'flex justify-between gap-55',
+                  children: [
+                    {
+                      classes: 'rtl color-highlight nowrap',
+                      textContent: c.dataset.label || headerList[i] || ''
+                    },
+                    {
+                      classes: 'text-right text-truncate',
+                      attrs: { title: c.innerText.trim().replace(/\s+/g, ' ') },
+                      textContent: c.innerText.trim(),
+                    }
+                  ]
+                }
+              })
+          },
+          {
+            tag: 'summary',
+            classes: 'summary',
+            textContent: 'More',
+          }
+        ]
+      });
+      row.appendChild(details);
+    }
 
-      // only one 'data-as-mobile-title'
-      const withTitle = [...children].filter(c => c.hasAttribute('data-as-mobile-title'));
-      if (withTitle.length > 1) {
-        withTitle.slice(1).forEach(c => c.removeAttribute('data-as-mobile-title'));
-      } else if (withTitle.length === 0 && children.length > 0) {
-        children[0].dataset.asMobileTitle = '';
-      }
+    // collapsed-column-details
+    if (!row.querySelector('.collapsed-column-details')) {
+      let hasCollapsed = false;
 
-      // mobile detail summary
-      if (!r.querySelector('.responsive-table-details')) {
-        const details = document.createElement('details');
-        details.className = 'details margin-top-5 responsive-table-details';
-
-        const summary = document.createElement('summary');
-        summary.className = 'summary';
-        summary.innerText = 'More';
-
-        const ul = document.createElement('ul');
-        ul.className = 'list list-with-transition size-h5';
-        r.style.setProperty('--table-template', template.join(' '));
-
-        [...children].forEach((c, i) => {
-          c.dataset.label = c.dataset.label || headerList[i] || '';
-          if (c.hasAttribute('data-show-on-mobile') || c.hasAttribute('data-as-mobile-title')) return;
-
-          const li = document.createElement('li');
-          li.className = 'flex justify-between gap-55';
-          li.innerHTML = `
-            <div class="rtl color-highlight nowrap">${c.dataset.label}</div>
-            <div class="text-right text-truncate" title="${c.innerText.trim().replace(/\s+/g, " ")}">
-              ${c.innerText.trim()}
-            </div>
-          `;
-          ul.appendChild(li);
-        });
-
-        details.appendChild(ul);
-        details.appendChild(summary);
-        r.appendChild(details);
-      }
-
-      // collapsed-column-details
-      if (!r.querySelector('.collapsed-column-details')) {
-        let hasCollapsed = false;
-
-        const collapseContainer = document.createElement('div');
-        [...children[0].attributes].forEach(attr => collapseContainer.setAttribute(attr.name, attr.value));
-        if (!collapseContainer.hasAttribute('data-to-sort')) collapseContainer.dataset.toSort = children[0].innerText.trim();
-
-        const details = document.createElement('details');
-        details.className = 'details collapsed-column-details';
-
-        const summary = document.createElement('summary');
-        summary.classList.add('text-truncate');
-        summary.title = children[0].innerText.trim().replace(/\s+/g, " ");
-        summary.innerText = children[0].textContent.trim();
-
-        const ul = document.createElement('ul');
-        ul.className = 'list list-with-transition size-h5';
-
-        let widest = '1fr';
-        [...children].forEach((c, i) => {
-          c.dataset.label = c.dataset.label || headerList[i] || '';
-          if (!c.hasAttribute('data-as-collapsed-column')) return;
-
-          hasCollapsed = true;
-
-          const li = document.createElement('li');
-          li.className = 'flex justify-between gap-55';
-
-          const divLabel = document.createElement('div');
-          divLabel.classList.add('rtl', 'color-highlight', 'nowrap');
-          divLabel.textContent = c.dataset.label;
-          li.appendChild(divLabel);
-
-          const divContent = document.createElement('div');
-          [...c.attributes].forEach(attr => {
-            if (['style', 'class'].includes(attr.name)) {
-              divContent.setAttribute(attr.name, attr.value)
-            }
-          });
-          divContent.classList.add('text-right', 'text-truncate');
-          divContent.title = c.innerText.trim().replace(/\s+/g, " "); // workaround text-truncate
-          divContent.innerHTML = c.innerHTML;
-          li.appendChild(divContent);
-
-          ul.appendChild(li);
-          headerCells[i].dataset.asCollapsedHeader = '';
-          template[i] = '0fr';
-        });
-
-        if (hasCollapsed) {
-          details.appendChild(ul);
-          details.appendChild(summary);
-          collapseContainer.appendChild(details);
-          r.replaceChild(collapseContainer, children[0]);
-
-          const sanitizedTemplate = template.filter(v => v !== '0fr');
-          header.style.setProperty('--table-template', sanitizedTemplate.join(' '));
-          r.style.setProperty('--table-template', sanitizedTemplate.join(' '));
+      const collapseContainer = createElementFn({
+        attrs: {
+          ...Array.from(cells[0].attributes).reduce((acc, attr) => {
+            acc[attr.name] = attr.value;
+            return acc;
+          }, {})
         }
-      }
-    });
-  }
+      });
+      if (!collapseContainer.hasAttribute('data-to-sort')) collapseContainer.dataset.toSort = cells[0].innerText.trim();
 
-  function sortTable({ t, t_index, body }) {
-    const col = colSorted[t_index];
-    const direction = colSortedDirection[t_index];
-    const sorted = [...data[t_index]].sort((a, b) => {
-      const x = a.children[col]?.dataset.toSort || a.children[col]?.innerText.trim() || '';
-      const y = b.children[col]?.dataset.toSort || b.children[col]?.innerText.trim() || '';
-      const nx = isNaN(x) ? x.toLowerCase() : +x;
-      const ny = isNaN(y) ? y.toLowerCase() : +y;
-      return nx > ny ? (direction === 'asc' ? 1 : -1) : nx < ny ? (direction === 'asc' ? -1 : 1) : 0;
-    });
-
-    const collapseAfter = body.dataset.collapseAfter;
-    let delay = 0;
-    sorted.forEach((r, i) => {
-      if (i > collapseAfter - 1) {
-        r.classList.add('collapsible-item');
-        r.style.setProperty('animation-delay', `${delay}ms`);
-        delay += 20;
-      } else {
-        r.classList.remove('collapsible-item');
-        r.style.removeProperty('animation-delay');
-      }
-      body.appendChild(r);
-    });
-
-    data[t_index] = sorted;
-
-    if (isPaginate[t_index]) {
-      data[t_index] = Array.from(sorted, r => {
-        r.classList.remove('collapsible-item');
-        r.style.removeProperty('animation-delay');
-        return r;
+      const details = createElementFn({
+        tag: 'details',
+        classes: 'details collapsed-column-details'
       });
 
-      body.innerHTML = '';
-      const start = (dataPage[t_index] - 1) * dataPageLimit[t_index];
-      const end = start + +dataPageLimit[t_index];
-      dataTable[t_index] = data[t_index].slice(start, end);
-      dataTable[t_index].forEach(row => body.appendChild(row));
+      const summary = createElementFn({
+        tag: 'summary',
+        classes: 'text-truncate',
+        props: { title: cells[0].innerText.trim().replace(/\s+/g, ' ') },
+        textContent: cells[0].textContent.trim(),
+      });
+
+      const ul = createElementFn({
+        tag: 'ul',
+        classes: 'list list-with-transition size-h5'
+      });
+
+      Array.from(cells).forEach((c, i) => {
+        c.dataset.label = c.dataset.label || headerList[i] || '';
+        if (!c.hasAttribute('data-as-collapsed-column')) return;
+
+        hasCollapsed = true;
+
+        const li = createElementFn({
+          tag: 'li',
+          classes: 'flex justify-between gap-55',
+          children: [
+            {
+              classes: 'rtl color-highlight nowrap',
+              textContent: c.dataset.label,
+            },
+            {
+              classes: `text-right text-truncate ${c.className || ''}`,
+              attrs: {
+                title: c.innerText.trim().replace(/\s+/g, ' '), // workaround text-truncate
+              },
+              style: Object.fromEntries(
+                [...c.style].map(p => [p, c.style[p]])
+              ),
+            }
+          ]
+        });
+        li.children[1].innerHTML = c.innerHTML;
+
+        ul.appendChild(li);
+        headerElement.children[i].dataset.asCollapsedHeader = '';
+        template[i] = '0fr';
+      });
+
+      if (hasCollapsed) {
+        details.appendChild(ul);
+        details.appendChild(summary);
+        collapseContainer.appendChild(details);
+        row.replaceChild(collapseContainer, cells[0]);
+
+        const sanitizedTemplate = template.filter(v => v !== '0fr');
+        headerElement.style.setProperty('--table-template', sanitizedTemplate.join(' '));
+        row.style.setProperty('--table-template', sanitizedTemplate.join(' '));
+      }
     }
+  }
 
-    const mobileSortElement = document.getElementById('responsive-table-mobile-sort-select-' + t_index);
-    const mobileSortDirectionElement = document.querySelector('#table-sort-direction-' + t_index);
-
-    // Sync Sort
-    t.querySelector('[table-header]').querySelectorAll('[sortable]').forEach((thead, i) => {
-      thead.dataset.sortDirection = 'none';
-      if (i === colSorted[t_index]) thead.dataset.sortDirection = colSortedDirection[t_index];
-
-      if (mobileSortElement) mobileSortElement.querySelector(`option[value="${colSorted[t_index]}"]`).selected = true;
-      if (mobileSortDirectionElement) mobileSortDirectionElement.dataset.sortDirection = colSortedDirection[t_index];
+  function createPaginationButton(page, isActive = false) {
+    return createElementFn({
+      tag: 'button',
+      textContent: page,
+      classes: `page-btn${isActive ? ' active' : ''}`,
     });
   }
 
-  function createMobileSortOption(text, value, selected) {
-    const option = document.createElement('option');
-    option.value = value;
-    option.text = text;
-    option.selected = selected;
-    return option;
+  function createPaginationEllipsis() {
+    return createElementFn({
+      tag: 'span',
+      textContent: '...',
+      classes: 'ellipses'
+    })
   }
 
-  function createMobileSortBtn(direction, t_index, onClick) {
-    const btn = document.createElement('div');
-    btn.className = 'table-sort-direction'
-    btn.id = 'table-sort-direction-' + t_index;
-    btn.dataset.sortDirection = direction;
-    btn.addEventListener('click', onClick);
-    return btn;
-  }
+  function updatePagination(params) {
+    const { footer, totalPage, paginationOptions, currentPage, targetPages } = params;
+    const { start, end } = targetPages;
+    paginationOptions.setAttribute('current-page', currentPage);
 
-  function setupMobileSort({ headerCells, t, t_index, body }) {
-    const mobileSortContainer = document.createElement('div');
-    mobileSortContainer.className = 'table-sort'
+    const paginationButtons = footer.querySelector('.pagination-buttons');
+    paginationButtons.innerHTML = '';
 
-    const label = document.createElement('label');
-    label.textContent = 'Sort by:';
-    label.htmlFor = 'responsive-table-mobile-sort-select-' + t_index;
+    const paginationSummary = footer.querySelector('.pagination-summary');
+    paginationSummary.querySelector('[summary-current]').textContent = start + 1;
+    const summarySize = +paginationOptions.getAttribute('total-page') === currentPage
+      ? +paginationOptions.getAttribute('total-entries')
+      : end + 1;
+    paginationSummary.querySelector('[summary-size]').textContent = summarySize;
 
-    let locked = false; // Just need to prevent spam glitches -_-
-    const directionBtn = createMobileSortBtn(colSortedDirection[t_index], t_index, () => {
-      if (locked) return;
-      locked = true;
-      const direction = colSortedDirection[t_index] === 'asc' ? 'desc' : 'asc';
-      colSortedDirection[t_index] = direction;
-      directionBtn.dataset.sortDirection = direction;
-
-      colSorted[t_index] = parseInt(mobileSort.value, 10);
-      if (!isNaN(colSorted[t_index])) sortTable({ t, t_index, body });
-      setTimeout(() => locked = false, 100);
+    const backButton = createElementFn({
+      tag: 'button',
+      textContent: '←',
+      classes: 'page-btn',
+      props: { disabled: currentPage === 1 }
     });
+    paginationButtons.appendChild(backButton);
 
-    const mobileSort = document.createElement('select');
-    mobileSort.className = 'table-sort-option'
-    mobileSort.id = 'responsive-table-mobile-sort-select-' + t_index;
-
-    mobileSort.innerHTML = '<option disabled selected>Sort by...</option>';
-    headerCells.forEach((c, i) => {
-      if (c.hasAttribute('data-as-collapsed-header')) return;
-      mobileSort.appendChild(createMobileSortOption(c.innerText.trim(), i, i === colSorted[t_index]));
-    });
-
-    label.appendChild(mobileSort);
-    mobileSortContainer.prepend(label);
-    mobileSortContainer.appendChild(directionBtn);
-    t.prepend(mobileSortContainer);
-
-    mobileSort.addEventListener('change', () => {
-      colSorted[t_index] = parseInt(mobileSort.value, 10);
-      sortTable({ t, t_index, body });
-    });
-  }
-
-  // #region ----------------------------------- PAGINATION --------------------------------------
-  function createPagination({ t, t_index, header, headerCells, body, template }) {
-    const container = document.createElement('div');
-    container.className = 'pagination-container';
-
-    const summary = document.createElement('div');
-    summary.className = 'pagination-summary';
-    container.appendChild(summary);
-
-    const pagination = document.createElement('div');
-    pagination.className = 'pagination-buttons';
-    container.appendChild(pagination);
-
-    t.appendChild(container);
-
-    updatePaginationSummary(summary, t_index);
-    updatePaginationButtons(pagination, { t, t_index, header, headerCells, body, template });
-  }
-
-  function updatePage({ t, t_index, header, headerCells, body, template }) {
-    const start = (dataPage[t_index] - 1) * dataPageLimit[t_index];
-    const end = start + +dataPageLimit[t_index];
-    dataTable[t_index] = data[t_index].slice(start, end);
-
-    body.innerHTML = '';
-    setupTable({ t, t_index, header, headerCells, body, template });
-
-    const summary = t.querySelector('.pagination-summary');
-    const pagination = t.querySelector('.pagination-buttons');
-    updatePaginationSummary(summary, t_index);
-    updatePaginationButtons(pagination, { t, t_index, header, headerCells, body, template });
-  }
-
-  function updatePaginationSummary(summaryEl, t_index) {
-    const start = (dataPage[t_index] - 1) * dataPageLimit[t_index] + 1;
-    const end = Math.min(dataPage[t_index] * dataPageLimit[t_index], data[t_index].length);
-    summaryEl.textContent = `Showing ${start} to ${end} of ${data[t_index].length} entries`;
-  }
-
-  function updatePaginationButtons(container, { t, t_index, header, headerCells, body, template }) {
-    container.innerHTML = '';
-    const totalPages = Math.ceil(data[t_index].length / dataPageLimit[t_index]);
-    const current = dataPage[t_index];
-
-    if (totalPages <= 1) return;
-
-    paginationBtnControllers[t_index]?.abort();
-    paginationBtnControllers[t_index] = new AbortController();
-
-    const btnHandler = e => {
-      if (!e.target.classList.contains('page-btn')) return;
-      const btn = e.target.textContent;
-      if (!isNaN(btn)) dataPage[t_index] = Number(btn);
-      else if (btn === '←' && current > 1) dataPage[t_index]--;
-      else if (btn === '→' && current < totalPages) dataPage[t_index]++;
-      else return;
-      updatePage({ t, t_index, header, headerCells, body, template });
-    }
-    container.addEventListener('click', btnHandler, { signal: paginationBtnControllers[t_index].signal });
-
-    function createBtn(page, isActive = false) {
-      const btn = document.createElement('button');
-      btn.textContent = page;
-      btn.className = 'page-btn';
-      if (isActive) btn.classList.add('active');
-      return btn;
-    }
-
-    function addEllipsis() {
-      const span = document.createElement('span');
-      span.className = 'page-ellipsis';
-      span.textContent = '...';
-      container.appendChild(span);
-    }
-
-    // Back Button
-    const backBtn = document.createElement('button');
-    backBtn.textContent = '←';
-    backBtn.className = 'page-btn';
-    backBtn.disabled = current === 1;
-    container.appendChild(backBtn);
-
-    // Page Buttons
     const pages = [];
 
-    if (totalPages <= 7) for (let i = 1; i <= totalPages; i++) pages.push(i);
-    else if (current <= 4) pages.push(1, 2, 3, 4, 5, '...', totalPages);
-    else if (current >= totalPages - 3) pages.push(1, '...', totalPages - 4, totalPages - 3, totalPages - 2, totalPages - 1, totalPages);
-    else pages.push(1, '...', current - 1, current, current + 1, '...', totalPages);
+    if (totalPage <= 7) for (let i = 1; i <= totalPage; i++) pages.push(i);
+    else if (currentPage <= 4) pages.push(1, 2, 3, 4, 5, '...', totalPage);
+      else if (currentPage >= totalPage - 3) pages.push(1, '...', totalPage - 4, totalPage - 3, totalPage - 2, totalPage - 1, totalPage);
+        else pages.push(1, '...', currentPage - 1, currentPage, currentPage + 1, '...', totalPage);
 
     for (const p of pages) {
-      if (p === '...') addEllipsis();
-      else container.appendChild(createBtn(p, p === current));
+      if (p === '...') paginationButtons.appendChild(createPaginationEllipsis());
+      else paginationButtons.appendChild(createPaginationButton(p, p === currentPage));
     }
 
-    // Next Button
-    const nextBtn = document.createElement('button');
-    nextBtn.textContent = '→';
-    nextBtn.className = 'page-btn';
-    nextBtn.disabled = current === totalPages;
-    container.appendChild(nextBtn);
+    const nextButton = createElementFn({
+      tag: 'button',
+      textContent: '→',
+      classes: 'page-btn',
+      props: { disabled: currentPage === totalPage }
+    });
+    paginationButtons.appendChild(nextButton);
   }
-  // #endregion-----------------------------------------------------------------------------------
 });

--- a/responsive-table/style.css
+++ b/responsive-table/style.css
@@ -1,14 +1,14 @@
-[responsive-table] .nowrap {
+div[responsive-table] .nowrap {
   white-space: nowrap;
 }
 
-[responsive-table] {
-  --table-columns: 10;
-  --table-template: repeat(var(--table-columns), 1fr);
+div[responsive-table] {
+  --table-template: repeat(10, 1fr);
   --widget-table-spacing: var(--widget-content-horizontal-padding);
   --widget-table-spacing-half: calc(var(--widget-table-spacing) / 2);
   --widget-table-spacing-quarter: calc(var(--widget-table-spacing) / 4);
-  display: none;
+  display: flex;
+  flex-direction: column;
   width: 100%;
   background: var(--color-widget-background);
   border-radius: var(--border-radius);
@@ -17,8 +17,12 @@
   backdrop-filter: var(--widget-background-blur, none);
 }
 
-[responsive-table] [table-header],
-[responsive-table] [table-row] {
+div[responsive-table] [table-body] {
+  flex: 1;
+}
+
+div[responsive-table] [table-header],
+div[responsive-table] [table-row] {
   display: grid;
   grid-template-columns: var(--table-template);
   border-bottom: 1px solid hsla(var(--bghs), calc(var(--scheme) (var(--scheme) var(--bgl) + 12%)), 0.5);
@@ -27,7 +31,7 @@
   gap: 1rem;
 }
 
-[responsive-table] [table-header] {
+div[responsive-table] [table-header] {
   font-weight: bolder;
   border-bottom: 1px solid var(--color-popover-border);
   text-align: left;
@@ -36,12 +40,12 @@
   background: var(--color-widget-background-highlight);
 }
 
-[responsive-table] [table-header]>[data-as-collapsed-header] {
+div[responsive-table] [table-header]>[data-as-collapsed-header] {
   display: none;
 }
 
-[responsive-table] [table-header]>div,
-[responsive-table] [table-row]>div {
+div[responsive-table] [table-header]>div,
+div[responsive-table] [table-row]>div {
   min-width: 0;
   white-space: nowrap;
   overflow: hidden;
@@ -49,11 +53,11 @@
   align-self: start;
 }
 
-[responsive-table] [table-row] {
+div[responsive-table] [table-row] {
   animation: rowEntrance .3s cubic-bezier(0.25, 1, 0.5, 1) backwards;
 }
 
-[responsive-table] [table-row]>[data-as-collapsed-column] {
+div[responsive-table] [table-row]>[data-as-collapsed-column] {
   display: none;
 }
 
@@ -64,17 +68,17 @@
   }
 }
 
-[responsive-table].show {
+div[responsive-table].show {
   opacity: 1;
   display: flex;
   transform: scaleY(1);
 }
 
-[responsive-table] {
+div[responsive-table] {
   animation: fadeIn 0.5s backwards cubic-bezier(0.16, 1, 0.3, 1);
 }
 
-[responsive-table] .table-sort {
+div[responsive-table] .table-sort {
   display: none;
   gap: 1rem;
   padding: 1rem;
@@ -82,7 +86,7 @@
   margin-bottom: 0.5rem;
 }
 
-[responsive-table] .table-sort>label {
+div[responsive-table] .table-sort>label {
   display: flex;
   width: 100%;
   white-space: nowrap;
@@ -90,7 +94,7 @@
   gap: 1rem;
 }
 
-[responsive-table] .table-sort-option {
+div[responsive-table] .table-sort-option {
   padding: 0.5rem 1rem;
   color: var(--color-text-highlight);
   background: var(--color-widget-background-highlight);
@@ -101,17 +105,17 @@
   width: 100%;
 }
 
-[responsive-table] .table-sort-option:hover {
+div[responsive-table] .table-sort-option:hover {
   border-color: var(--color-text-subdue);
 }
 
-[responsive-table] .table-sort-option:focus {
+div[responsive-table] .table-sort-option:focus {
   outline: none;
   border-color: var(--color-widget-content-border);
   box-shadow: 0 0 0 3px var(--color-widget-content-border);
 }
 
-[responsive-table] .table-sort-direction {
+div[responsive-table] .table-sort-direction {
   cursor: pointer;
   font-size: 20px;
   width: 22px;
@@ -122,12 +126,17 @@
   user-select: none;
 }
 
-[responsive-table] [sortable] {
+div[responsive-table] .table-sort-direction[disabled] {
+  opacity: .7;
+  cursor: not-allowed;
+}
+
+div[responsive-table] [sortable] {
   cursor: pointer;
 }
 
-[responsive-table] [sortable][data-sort-direction]:not([data-sort-direction="none"])::after,
-[responsive-table] .table-sort-direction[data-sort-direction]::after {
+div[responsive-table] [sortable][data-sort-direction]:not([data-sort-direction="none"])::after,
+div[responsive-table] .table-sort-direction[data-sort-direction]::after {
   content: '▲';
   display: inline-block;
   transition: transform 0.1s ease;
@@ -139,8 +148,8 @@
 }
 
 
-[responsive-table] [sortable][data-sort-direction="desc"]::after,
-[responsive-table] .table-sort-direction[data-sort-direction="desc"]::after {
+div[responsive-table] [sortable][data-sort-direction="desc"]::after,
+div[responsive-table] .table-sort-direction[data-sort-direction="desc"]::after {
   transform: translateZ(0) rotate(180deg) rotate(0.0008deg);
 }
 
@@ -154,11 +163,11 @@
   }
 }
 
-[responsive-table] .responsive-table-details {
+div[responsive-table] .responsive-table-details {
   display: none;
 }
 
-[responsive-table] .pagination-container {
+div[responsive-table] .pagination-container {
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -169,11 +178,11 @@
   background: var(--color-widget-background-highlight);
 }
 
-[responsive-table] .pagination-summary {
+div[responsive-table] .pagination-summary {
   flex: 1 1 auto;
 }
 
-[responsive-table] .pagination-buttons {
+div[responsive-table] .pagination-buttons {
   flex: 1 1 auto;
   display: flex;
   flex-wrap: wrap;
@@ -182,7 +191,13 @@
   min-height: 3rem;
 }
 
-[responsive-table] .pagination-buttons>.page-btn {
+div[responsive-table] .pagination-buttons > .ellipses {
+  align-content: flex-end;
+  user-select: none;
+  -moz-user-select: none;
+}
+
+div[responsive-table] .pagination-buttons > .page-btn {
   background: var(--color-widget-background);
   border-radius: var(--border-radius);
   width: 3rem;
@@ -192,12 +207,17 @@
   color: var(--color-text-highlight);
 }
 
-[responsive-table] .pagination-buttons>.page-btn.active {
+div[responsive-table] .pagination-buttons > .page-btn.active {
   font-weight: bolder;
   color: var(--color-primary)
 }
 
-[responsive-table] .page-ellipsis {
+div[responsive-table] .pagination-buttons > .page-btn[disabled] {
+  color: var(--color-text-subdue);
+  cursor: not-allowed;
+}
+
+div[responsive-table] .page-ellipsis {
   display: flex;
   align-items: center;
   justify-content: center;
@@ -208,43 +228,43 @@
   user-select: none;
 }
 
-[responsive-table] .collapsed-column-details>ul {
+div[responsive-table] .collapsed-column-details > ul {
   margin-bottom: 1rem;
   padding: 0.5rem 1rem;
   background: var(--color-widget-background-highlight);
   border-radius: var(--border-radius);
 }
 
-[responsive-table] .collapsed-column-details>ul>li {
+div[responsive-table] .collapsed-column-details>ul>li {
   line-height: 2rem;
 }
 
-[responsive-table] .collapsed-column-details>ul>li:not(:last-child) {
+div[responsive-table] .collapsed-column-details>ul>li:not(:last-child) {
   border-bottom: 1px solid var(--color-popover-border);
 }
 
-[responsive-table] .collapsed-column-details>summary {
+div[responsive-table] .collapsed-column-details>summary {
   user-select: none;
   cursor: pointer;
 }
 
-[responsive-table] .collapsed-column-details>summary::after {
+div[responsive-table] .collapsed-column-details>summary::after {
   line-height: 2.3em;
 }
 
-[responsive-table] .collapsed-column-details>summary::marker {
+div[responsive-table] .collapsed-column-details>summary::marker {
   font-size: 1.5rem;
 }
 
 @media (max-width: 768px) {
-  [responsive-table] {
+  div[responsive-table] {
     grid-template-columns: 1fr;
     background: none;
     border: none;
     box-shadow: none;
   }
 
-  [responsive-table] [table-row] {
+  div[responsive-table] [table-row] {
     display: block;
     border: 1px solid var(--color-widget-content-border);
     margin-bottom: 1.5rem;
@@ -255,11 +275,11 @@
     line-height: 2rem;
   }
 
-  [responsive-table] [table-header] {
+  div[responsive-table] [table-header] {
     display: none;
   }
 
-  [responsive-table] [table-row]>div[data-as-mobile-title] {
+  div[responsive-table] [table-row]>div[data-as-mobile-title] {
     position: absolute;
     left: 1rem;
     top: 1rem;
@@ -269,7 +289,7 @@
     display: unset;
   }
 
-  [responsive-table] [table-row]>div:not([data-as-mobile-title]) {
+  div[responsive-table] [table-row]>div:not([data-as-mobile-title]) {
     display: none;
     grid-template-columns: 1fr 1.5fr;
     align-items: center;
@@ -277,36 +297,36 @@
     gap: 0.5rem;
   }
 
-  [responsive-table] [table-row]>div:not([data-as-mobile-title])::before {
+  div[responsive-table] [table-row]>div:not([data-as-mobile-title])::before {
     content: attr(data-label);
     color: var(--color-text-highlight);
     margin-right: 0.5rem;
     text-align: left;
   }
 
-  [responsive-table] [table-row]>div:last-child {
+  div[responsive-table] [table-row]>div:last-child {
     margin-bottom: 0;
   }
 
-  [responsive-table] [table-row]>div[data-show-on-mobile] {
+  div[responsive-table] [table-row]>div[data-show-on-mobile] {
     display: grid;
   }
 
-  [responsive-table] .table-sort {
+  div[responsive-table] .table-sort {
     display: flex;
   }
 
-  [responsive-table] .responsive-table-details {
+  div[responsive-table] .responsive-table-details {
     display: block;
     padding: 0 1rem 0.2rem;
     background: var(--color-popover-background);
   }
 
-  [responsive-table] .responsive-table-details>summary {
+  div[responsive-table] .responsive-table-details>summary {
     color: var(--color-text-base);
   }
 
-  [responsive-table] .pagination-container {
+  div[responsive-table] .pagination-container {
     flex-direction: column;
     align-items: center;
     text-align: center;
@@ -314,32 +334,28 @@
     background: unset;
   }
 
-  [responsive-table] .pagination-buttons {
-    justify-content: center;
-  }
-
-  [responsive-table] .collapsed-column-details {
+  div[responsive-table] .collapsed-column-details {
     pointer-events: none;
   }
 
-  [responsive-table] .collapsed-column-details>summary {
+  div[responsive-table] .collapsed-column-details>summary {
     list-style: none;
   }
 
-  [responsive-table] .collapsed-column-details[open]>:not(summary) {
+  div[responsive-table] .collapsed-column-details[open]>:not(summary) {
     display: none;
   }
 
-  [responsive-table] .collapsed-column-details>summary::-webkit-details-marker {
+  div[responsive-table] .collapsed-column-details>summary::-webkit-details-marker {
     display: none;
   }
 
-  [responsive-table] [hide-on-mobile] {
+  div[responsive-table] [hide-on-mobile] {
     display: none !important;
   }
 
-  [responsive-table] [table-header]>div,
-  [responsive-table] [table-row]>div {
+  div[responsive-table] [table-header]>div,
+  div[responsive-table] [table-row]>div {
     padding-right: unset;
   }
 }

--- a/responsive-table/style.css
+++ b/responsive-table/style.css
@@ -319,7 +319,16 @@ div[responsive-table] .collapsed-column-details>summary::marker {
   div[responsive-table] .responsive-table-details {
     display: block;
     padding: 0 1rem 0.2rem;
-    background: var(--color-popover-background);
+  }
+
+  div[responsive-table] .responsive-table-details ul {
+    background: var(--color-widget-background-highlight);
+    border-radius: 0 0 var(--border-radius) var(--border-radius);
+    padding: 0 0.5rem;
+  }
+
+  div[responsive-table] details.responsive-table-details[open] .summary {
+    margin-bottom: 0;
   }
 
   div[responsive-table] .responsive-table-details>summary {


### PR DESCRIPTION
# ⚠️ BREAKING
Well, not much on the front. There's only a few changes in the `Glance widgets` that needs changing.

```html
<!-- container change -->
<div responsive-table>
<!-- to -->
<template responsive-table>

<!-- addition of pagination options, tag doesn't matter -->
<div table-pagination-options
    min-height="288"
    page-size="{{ $pageSize }}"
    total-entries="{{ $arrayLength }}"
></div>

<!-- header default sort change-->
<div table-header>
    <div sortable sort-default-asc data-width="3">System</div>
    <!-- to -->
    <div sortable data-sort-direction="asc" data-width="3">System</div>
</div>
```


## What's changed?
- Removed Glance widget native `collapse-after` and only allow `pagination
- Logic change, previously, every data of the table is rendered to the DOM.